### PR TITLE
Switch grid layout to CSS Grid

### DIFF
--- a/bloom-grid/src/core/instance.ts
+++ b/bloom-grid/src/core/instance.ts
@@ -1,6 +1,5 @@
 import type { GridState } from '../types';
 import { renderRow } from '../components/row';
-import { applyColumnStyles } from '../components/column';
 import { clearElement } from '../utils/dom';
 import { UndoRedoHistory } from '../state/history';
 
@@ -27,12 +26,24 @@ export class GridInstance {
     const body = document.createElement('div');
     body.className = 'body';
 
-    // apply column styles via first row
+    this.root.style.setProperty('--col-count', String(this.state.columns.length));
+    body.style.gridTemplateColumns = this.state.columns
+      .map((col) =>
+        col.widthMode === 'Manual' && col.width
+          ? `${col.width}%`
+          : 'minmax(30px, auto)'
+      )
+      .join(' ');
+    body.style.gridTemplateRows = this.state.rows
+      .map((row) =>
+        row.heightMode === 'Manual' && row.height
+          ? `${row.height}px`
+          : 'minmax(24px, auto)'
+      )
+      .join(' ');
+
     this.state.rows.forEach((row) => {
       const rowEl = renderRow(row);
-      Array.from(rowEl.children).forEach((cellEl, idx) => {
-        applyColumnStyles(cellEl as HTMLDivElement, this.state.columns[idx]);
-      });
       body.appendChild(rowEl);
     });
 

--- a/bloom-grid/src/stories/Grid.stories.ts
+++ b/bloom-grid/src/stories/Grid.stories.ts
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/html';
+import type { StoryObj, Meta } from '@storybook/html-vite';
 import { attach } from '../index';
 
 const meta: Meta = {

--- a/bloom-grid/src/styles/main.css.ts
+++ b/bloom-grid/src/styles/main.css.ts
@@ -5,11 +5,18 @@ export const bloomGridStyles = `
   height: 100%;
   border: 1px solid #ccc;
 }
+[data-bloom-grid-version="0"] .body {
+  display: grid;
+  grid-auto-flow: row;
+  grid-template-columns: repeat(var(--col-count), minmax(30px, auto));
+  grid-auto-rows: minmax(24px, auto);
+  width: 100%;
+  height: 100%;
+}
 [data-bloom-grid-version="0"] .row {
-  display: flex;
+  display: contents;
 }
 [data-bloom-grid-version="0"] .cell {
-  flex: 1;
   border: 1px solid #ddd;
   padding: 2px;
   min-width: 30px;

--- a/bloom-grid/src/ui/globalMenu.ts
+++ b/bloom-grid/src/ui/globalMenu.ts
@@ -1,3 +1,3 @@
-export function attachGlobalMenu(_root: HTMLElement) {
-  // placeholder for future menu
+export function attachGlobalMenu(root: HTMLElement): void {
+  void root; // placeholder for future menu
 }

--- a/bloom-grid/src/ui/menus.ts
+++ b/bloom-grid/src/ui/menus.ts
@@ -1,3 +1,3 @@
-export function attachCellMenu(_cell: HTMLElement) {
-  // placeholder for cell menu
+export function attachCellMenu(cell: HTMLElement): void {
+  void cell; // placeholder for cell menu
 }


### PR DESCRIPTION
## Summary
- use CSS Grid for layout
- compute grid template rows/columns in GridInstance
- fix unused variable linting
- update Storybook import

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.app.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684b766b4c448331912ce8775d50a1e0