### PR TITLE
Implement grid menu and column add

### DIFF
--- a/bloom-grid/src/core/instance.ts
+++ b/bloom-grid/src/core/instance.ts
@@ -2,6 +2,9 @@ import type { GridState } from '../types';
 import { renderRow } from '../components/row';
 import { clearElement } from '../utils/dom';
 import { UndoRedoHistory } from '../state/history';
+import { attachGlobalMenu } from '../ui/globalMenu';
+import { createGhostPill } from '../ui/ghostPill';
+import { addColumn } from '../state/actions';
 
 export class GridInstance {
   state: GridState;
@@ -23,6 +26,8 @@ export class GridInstance {
   render() {
     clearElement(this.root);
     this.root.classList.add('bloom-grid');
+    this.root.dataset.borderStyle = this.state.borderStyle;
+    this.root.dataset.borderColor = this.state.borderColor;
     const body = document.createElement('div');
     body.className = 'body';
 
@@ -48,6 +53,16 @@ export class GridInstance {
     });
 
     this.root.appendChild(body);
+
+    const addBtn = createGhostPill();
+    addBtn.style.position = 'absolute';
+    addBtn.style.top = '-12px';
+    addBtn.style.right = '0';
+    addBtn.addEventListener('click', () => {
+      this.setState(addColumn(this.state));
+    });
+    this.root.appendChild(addBtn);
+    attachGlobalMenu(this);
   }
 
   destroy() {

--- a/bloom-grid/src/styles/main.css.ts
+++ b/bloom-grid/src/styles/main.css.ts
@@ -3,7 +3,8 @@ export const bloomGridStyles = `
   display: block;
   width: 100%;
   height: 100%;
-  border: 1px solid #ccc;
+  position: relative;
+  border: 1px solid var(--bloom-border-color, #ccc);
 }
 [data-bloom-grid-version="0"] .body {
   display: grid;
@@ -30,5 +31,64 @@ export const bloomGridStyles = `
   border-radius: 9999px;
   border: 1px solid #ccc;
   cursor: pointer;
+}
+
+[data-bloom-grid-version="0"][data-border-style="None"] {
+  border: none;
+}
+[data-bloom-grid-version="0"][data-border-style="Outline"] .cell {
+  border: none;
+}
+[data-bloom-grid-version="0"][data-border-style="None"] .cell {
+  border: none;
+}
+[data-bloom-grid-version="0"][data-border-style="All"] .cell {
+  border: 1px solid var(--bloom-border-color, #ccc);
+}
+[data-bloom-grid-version="0"][data-border-color="Black"] {
+  --bloom-border-color: black;
+}
+[data-bloom-grid-version="0"][data-border-color="Grey"] {
+  --bloom-border-color: grey;
+}
+[data-bloom-grid-version="0"][data-border-color="None"] {
+  --bloom-border-color: transparent;
+}
+
+[data-bloom-grid-version="0"] .menu-icon {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  width: 0;
+  height: 0;
+  border-left: 8px solid transparent;
+  border-bottom: 8px solid black;
+  cursor: pointer;
+  display: none;
+}
+[data-bloom-grid-version="0"]:hover .menu-icon {
+  display: block;
+}
+[data-bloom-grid-version="0"] .grid-menu {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: white;
+  border: 1px solid #ccc;
+  padding: 4px;
+  z-index: 10;
+}
+[data-bloom-grid-version="0"] .grid-menu ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+[data-bloom-grid-version="0"] .grid-menu li {
+  padding: 2px 6px;
+  cursor: pointer;
+}
+[data-bloom-grid-version="0"] .grid-menu li.disabled {
+  color: #888;
+  pointer-events: none;
 }
 `;

--- a/bloom-grid/src/ui/globalMenu.ts
+++ b/bloom-grid/src/ui/globalMenu.ts
@@ -1,3 +1,65 @@
-export function attachGlobalMenu(root: HTMLElement): void {
-  void root; // placeholder for future menu
+import type { GridInstance } from '../core/instance';
+import type { BorderStyle, BorderColor } from '../types';
+
+function createMenuItem(label: string, active: boolean, onClick: () => void): HTMLLIElement {
+  const li = document.createElement('li');
+  li.textContent = label;
+  if (active) {
+    li.classList.add('disabled');
+  } else {
+    li.addEventListener('click', onClick);
+  }
+  return li;
+}
+
+export function attachGlobalMenu(instance: GridInstance): void {
+  const root = instance.root;
+  if (!root.querySelector('.menu-icon')) {
+    const icon = document.createElement('div');
+    icon.className = 'menu-icon';
+    root.appendChild(icon);
+
+    icon.addEventListener('click', () => {
+      const existing = root.querySelector('.grid-menu');
+      if (existing) {
+        existing.remove();
+        return;
+      }
+      const menu = document.createElement('div');
+      menu.className = 'grid-menu';
+
+      const styleList = document.createElement('ul');
+      styleList.appendChild(document.createElement('li')).textContent = 'Borders';
+      (['None', 'Outline', 'All'] as BorderStyle[]).forEach((style) => {
+        styleList.appendChild(
+          createMenuItem(style, instance.state.borderStyle === style, () => {
+            instance.setState({ ...instance.state, borderStyle: style });
+            menu.remove();
+          })
+        );
+      });
+      const colorList = document.createElement('ul');
+      colorList.appendChild(document.createElement('li')).textContent = 'Border Color';
+      (['Black', 'Grey', 'None'] as BorderColor[]).forEach((color) => {
+        colorList.appendChild(
+          createMenuItem(color, instance.state.borderColor === color, () => {
+            instance.setState({ ...instance.state, borderColor: color });
+            menu.remove();
+          })
+        );
+      });
+
+      menu.appendChild(styleList);
+      menu.appendChild(colorList);
+      root.appendChild(menu);
+    });
+  }
+
+  if (!root.dataset.menuListener) {
+    root.addEventListener('mouseleave', () => {
+      const existing = root.querySelector('.grid-menu');
+      existing?.remove();
+    });
+    root.dataset.menuListener = '1';
+  }
 }


### PR DESCRIPTION
## Summary
- support border style/color through dataset
- add global menu icon to adjust grid borders
- add column via floating + button
- style menu and border handling

## Testing
- `npm run build` *(fails: Cannot find module 'uuid')*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-storybook')*
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: Cannot find module 'uuid')*

------
https://chatgpt.com/codex/tasks/task_e_684b838e987883318f83b6cf83a9a617